### PR TITLE
feat: add `profile [INDEX]` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -43,7 +43,11 @@ public class CommandResult {
         this.addVisit = addVisit;
         this.deleteVisit = deleteVisit;
         this.exit = exit;
+    }
 
+    public CommandResult(String feedbackToUser, int idx) {
+        this(feedbackToUser, false, false, false, false);
+        this.index = idx;
     }
 
     public CommandResult(String feedbackToUser, int idx, String date) {
@@ -62,7 +66,8 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false, false);
+        this(feedbackToUser, false, false, false,
+                false);
     }
 
     public String getFeedbackToUser() {

--- a/src/main/java/seedu/address/logic/commands/ProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProfileCommand.java
@@ -1,0 +1,71 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+/**
+ * Changes the visitList of an existing person in the address book.
+ */
+public class ProfileCommand extends Command {
+    public static final String COMMAND_WORD = "profile";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Opens the detailed profile of the patient identified"
+            + "by the index number used in the last person listing. "
+            + "The profile can be generated into a log file subsequently.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Example: " + COMMAND_WORD + " 1 ";
+
+    // public static final String MESSAGE_VIEW_PROFILE_SUCCESS = "Generated profile view of : %1$s";
+    public static final String MESSAGE_VIEW_PROFILE_SUCCESS = "DEBUG: Profile Command Recognized! Target: %1$s";
+
+    private final Index index;
+
+    /**
+     * @param index of the person in the last listing whose profile is to be viewed
+     */
+    public ProfileCommand(Index index) {
+        requireAllNonNull(index);
+
+        this.index = index;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person personToEdit = lastShownList.get(index.getZeroBased());
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+
+        return new CommandResult(String.format(MESSAGE_VIEW_PROFILE_SUCCESS, personToEdit), index.getOneBased());
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof ProfileCommand)) {
+            return false;
+        }
+
+        // state check
+        ProfileCommand e = (ProfileCommand) other;
+        return index.equals(e.index);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ProfileCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ProfileCommand.java
@@ -24,7 +24,7 @@ public class ProfileCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1 ";
 
     // public static final String MESSAGE_VIEW_PROFILE_SUCCESS = "Generated profile view of : %1$s";
-    public static final String MESSAGE_VIEW_PROFILE_SUCCESS = "DEBUG: Profile Command Recognized! Target: %1$s";
+    public static final String MESSAGE_VIEW_PROFILE_SUCCESS = "Profile Command Recognized! Target: %1$s";
 
     private final Index index;
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -17,6 +17,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ProfileCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -71,6 +72,9 @@ public class AddressBookParser {
         case DeleteVisitCommand.COMMAND_WORD:
             System.out.println(commandWord);
             return new DeleteVisitCommandParser().parse(arguments);
+
+        case ProfileCommand.COMMAND_WORD:
+            return new ProfileCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ProfileCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ProfileCommandParser.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.ProfileCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new {@code RemarkCommand} object
+ */
+public class ProfileCommandParser implements Parser<ProfileCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code RemarkCommand}
+     * and returns a {@code RemarkCommand} object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ProfileCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
+
+        Index index;
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (IllegalValueException ive) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ProfileCommand.MESSAGE_USAGE), ive);
+        }
+
+        return new ProfileCommand(index);
+    }
+}


### PR DESCRIPTION
In fulfilment of #32.
TLDR of diff:
- `profile [INDEX]` is now a recognizable command word and checks if user input is correct.
- User help text added to aid user when parsing error is thrown.